### PR TITLE
Update news with neurips workshop acceptances

### DIFF
--- a/_pages/news.html
+++ b/_pages/news.html
@@ -3,7 +3,7 @@
     let news = [
         {
             date: "September 2025",
-            content: "Three papers accepted at the NeurIPS 2025 Mechanistic Interpretability Workshop: Overcoming Sparsity Artifacts in Crosscoders to Interpret Chat-Tuning (Spotlight, top 13%; also accepted as a poster at NeurIPS 2025 main), Narrow Finetuning Leaves Clearly Readable Traces in the Activation Differences (Spotlight), and nnterp: A Standardized Interface for Mechanistic Interpretability of Transformers (Poster). I am main author on nnterp and Overcoming."
+            content: "NeurIPS 2025 main poster: Overcoming Sparsity Artifacts in Crosscoders to Interpret Chat-Tuning. At the NeurIPS 2025 Mechanistic Interpretability Workshop: Overcoming (Spotlight, top 13%; co-led with Julian Minder), Narrow Finetuning Leaves Clearly Readable Traces in the Activation Differences (Spotlight; led by Julian Minder), and nnterp: A Standardized Interface for Mechanistic Interpretability of Transformers (Poster; solo)."
         },
         {
             date: "May 2025",

--- a/_pages/news.html
+++ b/_pages/news.html
@@ -3,7 +3,11 @@
     let news = [
         {
             date: "September 2025",
-            content: "NeurIPS 2025 main poster: Overcoming Sparsity Artifacts in Crosscoders to Interpret Chat-Tuning. At the NeurIPS 2025 Mechanistic Interpretability Workshop: Overcoming (Spotlight, top 13%; co-led with Julian Minder), Narrow Finetuning Leaves Clearly Readable Traces in the Activation Differences (Spotlight; led by Julian Minder), and nnterp: A Standardized Interface for Mechanistic Interpretability of Transformers (Poster; solo)."
+            content: "Mentoring two SPAR model-diffing projects: one on understanding model persona, and one on disentangling finetuning objectives."
+        },
+        {
+            date: "September 2025",
+            content: "Excited to share: Overcoming Sparsity Artifacts in Crosscoders to Interpret Chat-Tuning was accepted to NeurIPS 2025 main (poster). At the Mech Interp workshop, we have two spotlights — Overcoming (co-led with Julian Minder, top 13%) and Narrow Finetuning Leaves Clearly Readable Traces in the Activation Differences (led by Julian Minder) — plus a poster for nnterp (solo)."
         },
         {
             date: "May 2025",

--- a/_pages/news.html
+++ b/_pages/news.html
@@ -2,6 +2,10 @@
 <script>
     let news = [
         {
+            date: "September 2025",
+            content: "Three papers accepted at the NeurIPS 2025 Mechanistic Interpretability Workshop: Overcoming Sparsity Artifacts in Crosscoders to Interpret Chat-Tuning (Spotlight, top 13%; also accepted as a poster at NeurIPS 2025 main), Narrow Finetuning Leaves Clearly Readable Traces in the Activation Differences (Spotlight), and nnterp: A Standardized Interface for Mechanistic Interpretability of Transformers (Poster). I am main author on nnterp and Overcoming."
+        },
+        {
             date: "May 2025",
             content: "Our paper <a href='https://arxiv.org/abs/2411.08745'>Separating Tongue from Thought: Activation Patching Reveals Language-Agnostic Concept Representations in Transformers</a> was accepted as a poster in ACL 2025 main conference!",
         },

--- a/_pages/news.html
+++ b/_pages/news.html
@@ -3,11 +3,15 @@
     let news = [
         {
             date: "September 2025",
-            content: "Mentoring two SPAR model-diffing projects: one on understanding model persona, and one on disentangling finetuning objectives."
+            content: "Excited to share that our crosscoder paper <a href='https://arxiv.org/abs/2504.02922'>Overcoming Sparsity Artifacts in Crosscoders to Interpret Chat-Tuning</a> was accepted to NeurIPS 2025 main (poster)!"
         },
         {
             date: "September 2025",
-            content: "Excited to share: Overcoming Sparsity Artifacts in Crosscoders to Interpret Chat-Tuning was accepted to NeurIPS 2025 main (poster). At the Mech Interp workshop, we have two spotlights — Overcoming (co-led with Julian Minder, top 13%) and Narrow Finetuning Leaves Clearly Readable Traces in the Activation Differences (led by Julian Minder) — plus a poster for nnterp (solo)."
+            content: "At the NeurIPS Mech Interp workshop, we have two spotlights (top 13%) — our <a href='https://arxiv.org/abs/2504.02922'>crosscoder paper</a> (co-led with Julian Minder) and Narrow Finetuning Leaves Clearly Readable Traces in the Activation Differences (led by Julian Minder) — plus a poster for my mech interp library <a href='/nnterp/'>nnterp</a>."
+        },
+        {
+            date: "September 2025",
+            content: "Mentoring two <a href='https://sparai.org/'>SPAR</a> model-diffing projects: one on understanding model persona (with Emmett Brosowsky, Iwona Kotlarska and Riya Tyagi), and one on disentangling finetuning objectives (with Greg Kocher and Aishwarya Balwani)!"
         },
         {
             date: "May 2025",

--- a/_research/2024-11-crosscoders.md
+++ b/_research/2024-11-crosscoders.md
@@ -5,9 +5,9 @@ authors: "Clément Dumas*, Julian Minder*, Caden Juang, Bilal Chugtai, Neel Nand
 permalink: /research/2024-11-crosscoders
 excerpt: ''
 date: 2024-11-15
-venue: "MATS Program Project"
+venue: "NeurIPS 2025 (Poster)"
 paperurl: https://arxiv.org/pdf/2504.02922
-posturl: https://www.notion.so/What-We-Learned-Trying-to-Diff-Base-and-Chat-Models-And-Why-It-Matters-215cdfe65ca380e0a6c1f444d25a585c
+posturl: https://www.alignmentforum.org/posts/xmpauEXEerzYcJKNm/what-we-learned-trying-to-diff-base-and-chat-models-and-why
 codeurl: https://github.com/science-of-finetuning/sparsity-artifacts-crosscoders
 ---
 


### PR DESCRIPTION
Add a news item announcing three papers accepted at the NeurIPS 2025 MechInterp Workshop (two spotlights, one poster), with one also accepted as a NeurIPS main conference poster.

---
<a href="https://cursor.com/background-agent?bcId=bc-1e6780ae-b119-4ed5-a70d-7cbc7cfe7ad2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1e6780ae-b119-4ed5-a70d-7cbc7cfe7ad2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

