### PR TITLE
Setup configurable domain redirects

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,75 @@
+# GitHub Actions workflow to build and deploy Jekyll site with custom build scripts
+#
+# This workflow:
+# 1. Runs all Python scripts in _build_scripts/ (in the order specified in config.yml)
+# 2. Builds the Jekyll site
+# 3. Deploys to GitHub Pages
+
+name: Deploy Jekyll site to Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["master", "main"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Python dependencies
+        run: pip install pyyaml
+
+      - name: Run build scripts
+        run: python _build_scripts/run_build_scripts.py
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1'
+          bundler-cache: true
+
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v4
+
+      - name: Build with Jekyll
+        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+        env:
+          JEKYLL_ENV: production
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -1,31 +1,145 @@
-A Github Pages template for academic websites. This was forked (then detached) by [Stuart Geiger](https://github.com/staeiou) from the [Minimal Mistakes Jekyll Theme](https://mmistakes.github.io/minimal-mistakes/), which is © 2016 Michael Rose and released under the MIT License. See LICENSE.md.
+# butanium.github.io
 
-I think I've got things running smoothly and fixed some major bugs, but feel free to file issues or make pull requests if you want to improve the generic template / theme.
+Personal academic website built with Jekyll and deployed via GitHub Actions.
 
-### Note: if you are using this repo and now get a notification about a security vulnerability, delete the Gemfile.lock file. 
+## Quick Start
 
-# Instructions
+### Adding a Redirect
 
-1. Register a GitHub account if you don't have one and confirm your e-mail (required!)
-1. Fork [this repository](https://github.com/academicpages/academicpages.github.io) by clicking the "fork" button in the top right. 
-1. Go to the repository's settings (rightmost item in the tabs that start with "Code", should be below "Unwatch"). Rename the repository "[your GitHub username].github.io", which will also be your website's URL.
-1. Set site-wide configuration and create content & metadata (see below -- also see [this set of diffs](http://archive.is/3TPas) showing what files were changed to set up [an example site](https://getorg-testacct.github.io) for a user with the username "getorg-testacct")
-1. Upload any files (like PDFs, .zip files, etc.) to the files/ directory. They will appear at https://[your GitHub username].github.io/files/example.pdf.  
-1. Check status by going to the repository settings, in the "GitHub pages" section
-1. (Optional) Use the Jupyter notebooks or python scripts in the `markdown_generator` folder to generate markdown files for publications and talks from a TSV file.
+To redirect a path on this site to an external URL:
 
-See more info at https://academicpages.github.io/
+1. Edit `_data/redirects.yml`:
+   ```yaml
+   redirects:
+     nnterp: https://ndif-team.github.io/nnterp/
+     my-project: https://example.com/destination/
+   ```
 
-## To run locally (not on GitHub Pages, to serve on your own computer)
+2. Push to `main` or `master` branch
 
-1. Clone the repository and made updates as detailed above
-1. Make sure you have ruby-dev, bundler, and nodejs installed: `sudo apt install ruby-dev ruby-bundler nodejs`
-1. Run `bundle clean` to clean up the directory (no need to run `--force`)
-1. Run `bundle install` to install ruby dependencies. If you get errors, delete Gemfile.lock and try again.
-1. Run `bundle exec jekyll liveserve` to generate the HTML and serve it from `localhost:4000` the local server will automatically rebuild and refresh the pages on change.
+That's it! The redirect pages are generated automatically during build.
 
-# Changelog -- bugfixes and enhancements
+### Running Locally
 
-There is one logistical issue with a ready-to-fork template theme like academic pages that makes it a little tricky to get bug fixes and updates to the core theme. If you fork this repository, customize it, then pull again, you'll probably get merge conflicts. If you want to save your various .yml configuration files and markdown files, you can delete the repository and fork it again. Or you can manually patch. 
+```bash
+# Install dependencies
+bundle install
+pip install pyyaml
 
-To support this, all changes to the underlying code appear as a closed issue with the tag 'code change' -- get the list [here](https://github.com/academicpages/academicpages.github.io/issues?q=is%3Aclosed%20is%3Aissue%20label%3A%22code%20change%22%20). Each issue thread includes a comment linking to the single commit or a diff across multiple commits, so those with forked repositories can easily identify what they need to patch.
+# Run build scripts (generates redirects, etc.)
+python _build_scripts/run_build_scripts.py
+
+# Start local server
+bundle exec jekyll serve
+```
+
+Visit `http://localhost:4000` to preview your site.
+
+---
+
+## Build System
+
+This site uses a custom build system that runs Python scripts before Jekyll builds.
+
+### How It Works
+
+1. **GitHub Actions** triggers on push to `main`/`master`
+2. **Build scripts** in `_build_scripts/` run in order (defined in `config.yml`)
+3. **Jekyll** builds the site
+4. **GitHub Pages** deploys the result
+
+### Adding a New Build Script
+
+1. Create your script in `_build_scripts/`:
+   ```python
+   # _build_scripts/my_script.py
+   def main():
+       print("Doing something...")
+       return 0  # Return 0 for success, non-zero for failure
+
+   if __name__ == '__main__':
+       exit(main())
+   ```
+
+2. Add it to `_build_scripts/config.yml` in the order you want it to run:
+   ```yaml
+   scripts:
+     - generate_redirects.py
+     - my_script.py  # Add your script here
+   ```
+
+3. Push your changes
+
+**Important:** All `.py` files in `_build_scripts/` MUST be listed in `config.yml`. The build will fail if any script is missing from the config. This ensures you explicitly decide the execution order.
+
+### Build Scripts Config
+
+`_build_scripts/config.yml` controls which scripts run and in what order:
+
+```yaml
+scripts:
+  - generate_redirects.py  # Runs first
+  - another_script.py      # Runs second
+  - final_script.py        # Runs last
+```
+
+### Testing Build Scripts Locally
+
+```bash
+python _build_scripts/run_build_scripts.py
+```
+
+This will:
+- Validate all scripts are in the config
+- Run each script in order
+- Report success/failure
+
+---
+
+## Project Structure
+
+```
+.
+├── _build_scripts/           # Python scripts that run before Jekyll
+│   ├── config.yml            # Script execution order
+│   ├── run_build_scripts.py  # Build runner (don't edit)
+│   └── generate_redirects.py # Generates redirect pages
+├── _data/
+│   ├── redirects.yml         # Configure URL redirects here
+│   └── ...
+├── _layouts/
+│   ├── redirect.html         # Redirect page template
+│   └── ...
+├── _pages/                   # Site pages
+├── _redirects/               # Generated redirect pages (don't edit)
+├── _config.yml               # Jekyll configuration
+├── .github/workflows/
+│   └── deploy.yml            # GitHub Actions workflow
+└── ...
+```
+
+---
+
+## Configuration Reference
+
+### Redirects (`_data/redirects.yml`)
+
+```yaml
+redirects:
+  # Simple redirect
+  old-page: https://new-site.com/page/
+
+  # Nested path
+  projects/old-project: https://github.com/user/new-repo
+
+  # External site
+  docs: https://docs.example.com/
+```
+
+Each entry creates a page at `/<path>/` that redirects to the destination URL.
+
+---
+
+## Original Template
+
+This site was forked from [academicpages](https://github.com/academicpages/academicpages.github.io). See `readme.old.md` for the original documentation.

--- a/_build_scripts/config.yml
+++ b/_build_scripts/config.yml
@@ -1,0 +1,10 @@
+# Build Scripts Configuration
+#
+# This file defines which Python scripts run before Jekyll builds the site.
+# All .py files in _build_scripts/ MUST be listed here, or the build will fail.
+# This ensures you explicitly decide the execution order for each script.
+#
+# Scripts are executed in the order listed below.
+
+scripts:
+  - generate_redirects.py

--- a/_build_scripts/generate_redirects.py
+++ b/_build_scripts/generate_redirects.py
@@ -6,7 +6,7 @@ This script reads the redirects configuration and generates individual
 redirect pages in the _redirects/ directory.
 
 Usage:
-    python scripts/generate_redirects.py
+    python _build_scripts/generate_redirects.py
 """
 
 import os

--- a/_build_scripts/run_build_scripts.py
+++ b/_build_scripts/run_build_scripts.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""
+Build Script Runner
+
+This script runs all Python build scripts in the order specified in config.yml.
+It validates that ALL .py files in _build_scripts/ are listed in the config,
+ensuring developers explicitly decide the execution order for each script.
+
+Usage:
+    python _build_scripts/run_build_scripts.py
+
+Exit codes:
+    0 - All scripts ran successfully
+    1 - Validation failed (unlisted scripts found)
+    2 - A script failed during execution
+"""
+
+import subprocess
+import sys
+import yaml
+from pathlib import Path
+
+# Get the directory containing this script
+SCRIPTS_DIR = Path(__file__).parent
+CONFIG_FILE = SCRIPTS_DIR / "config.yml"
+REPO_ROOT = SCRIPTS_DIR.parent
+
+
+def load_config():
+    """Load the build scripts configuration."""
+    if not CONFIG_FILE.exists():
+        print(f"ERROR: {CONFIG_FILE} not found!")
+        print("Create a config.yml file listing all build scripts.")
+        sys.exit(1)
+
+    with open(CONFIG_FILE, 'r') as f:
+        config = yaml.safe_load(f)
+
+    return config.get('scripts', [])
+
+
+def get_all_python_scripts():
+    """Get all .py files in the build scripts directory, excluding this runner."""
+    scripts = set()
+    for py_file in SCRIPTS_DIR.glob("*.py"):
+        # Exclude the runner script itself
+        if py_file.name != "run_build_scripts.py":
+            scripts.add(py_file.name)
+    return scripts
+
+
+def validate_config(configured_scripts, actual_scripts):
+    """
+    Validate that all Python scripts are listed in the config.
+
+    Returns True if valid, False otherwise.
+    """
+    configured_set = set(configured_scripts)
+
+    # Check for scripts in folder but not in config
+    unlisted = actual_scripts - configured_set
+    if unlisted:
+        print("=" * 60)
+        print("BUILD FAILED: Unlisted scripts found!")
+        print("=" * 60)
+        print()
+        print("The following scripts exist in _build_scripts/ but are NOT")
+        print("listed in config.yml:")
+        print()
+        for script in sorted(unlisted):
+            print(f"  - {script}")
+        print()
+        print("Please add them to _build_scripts/config.yml in the order")
+        print("you want them to run, or delete them if not needed.")
+        print()
+        print("This check ensures you explicitly decide the execution order")
+        print("for each build script.")
+        print("=" * 60)
+        return False
+
+    # Check for scripts in config but not in folder (warning only)
+    missing = configured_set - actual_scripts
+    if missing:
+        print("WARNING: The following scripts are in config.yml but don't exist:")
+        for script in sorted(missing):
+            print(f"  - {script}")
+        print()
+
+    return True
+
+
+def run_script(script_name):
+    """Run a single build script."""
+    script_path = SCRIPTS_DIR / script_name
+
+    if not script_path.exists():
+        print(f"  SKIP: {script_name} (file not found)")
+        return True
+
+    print(f"  Running: {script_name}")
+    print("-" * 40)
+
+    result = subprocess.run(
+        [sys.executable, str(script_path)],
+        cwd=str(REPO_ROOT)
+    )
+
+    print("-" * 40)
+
+    if result.returncode != 0:
+        print(f"  FAILED: {script_name} (exit code {result.returncode})")
+        return False
+
+    print(f"  OK: {script_name}")
+    return True
+
+
+def main():
+    """Main entry point."""
+    print("=" * 60)
+    print("Build Scripts Runner")
+    print("=" * 60)
+    print()
+
+    # Load configuration
+    configured_scripts = load_config()
+    actual_scripts = get_all_python_scripts()
+
+    print(f"Scripts in config: {len(configured_scripts)}")
+    print(f"Scripts in folder: {len(actual_scripts)}")
+    print()
+
+    # Validate all scripts are configured
+    if not validate_config(configured_scripts, actual_scripts):
+        return 1
+
+    if not configured_scripts:
+        print("No scripts configured. Nothing to do.")
+        return 0
+
+    print(f"Running {len(configured_scripts)} script(s) in order...")
+    print()
+
+    # Run scripts in order
+    for script_name in configured_scripts:
+        if not run_script(script_name):
+            print()
+            print("BUILD FAILED: Script execution failed.")
+            return 2
+        print()
+
+    print("=" * 60)
+    print("All build scripts completed successfully!")
+    print("=" * 60)
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/_config.yml
+++ b/_config.yml
@@ -198,6 +198,8 @@ collections:
   talks:
     output: true
     permalink: /:collection/:path/
+  redirects:
+    output: true
 
 
 # Defaults
@@ -273,6 +275,13 @@ defaults:
       author_profile: true
       share: false
       comments: true
+  # _redirects
+  - scope:
+      path: ""
+      type: redirects
+    values:
+      layout: redirect
+      sitemap: false
 
 
 # Sass/SCSS

--- a/_data/redirects.yml
+++ b/_data/redirects.yml
@@ -5,8 +5,8 @@
 #   nnterp: https://ndif-team.github.io/nnterp/
 #   foo/bar: https://bar.foo.com/
 #
-# After editing this file, run: python scripts/generate_redirects.py
-# to regenerate the redirect pages.
+# These redirects are automatically generated during the GitHub Actions build.
+# Just edit this file and push - no manual steps needed!
 
 redirects:
   nnterp: https://ndif-team.github.io/nnterp/

--- a/_data/redirects.yml
+++ b/_data/redirects.yml
@@ -1,0 +1,14 @@
+# Configurable Redirects
+# Format: path_on_this_site: destination_url
+#
+# Example:
+#   nnterp: https://ndif-team.github.io/nnterp/
+#   foo/bar: https://bar.foo.com/
+#
+# After editing this file, run: python scripts/generate_redirects.py
+# to regenerate the redirect pages.
+
+redirects:
+  nnterp: https://ndif-team.github.io/nnterp/
+  # Example nested path (remove this if not needed):
+  # foo/bar: https://bar.foo.com/

--- a/_layouts/redirect.html
+++ b/_layouts/redirect.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="refresh" content="0; url={{ page.redirect_to }}">
+  <link rel="canonical" href="{{ page.redirect_to }}">
+  <title>Redirecting...</title>
+  <script>
+    window.location.replace("{{ page.redirect_to }}");
+  </script>
+</head>
+<body>
+  <p>Redirecting to <a href="{{ page.redirect_to }}">{{ page.redirect_to }}</a>...</p>
+</body>
+</html>

--- a/_redirects/nnterp.md
+++ b/_redirects/nnterp.md
@@ -1,0 +1,4 @@
+---
+permalink: /nnterp/
+redirect_to: https://ndif-team.github.io/nnterp/
+---

--- a/readme.old.md
+++ b/readme.old.md
@@ -1,0 +1,31 @@
+A Github Pages template for academic websites. This was forked (then detached) by [Stuart Geiger](https://github.com/staeiou) from the [Minimal Mistakes Jekyll Theme](https://mmistakes.github.io/minimal-mistakes/), which is © 2016 Michael Rose and released under the MIT License. See LICENSE.md.
+
+I think I've got things running smoothly and fixed some major bugs, but feel free to file issues or make pull requests if you want to improve the generic template / theme.
+
+### Note: if you are using this repo and now get a notification about a security vulnerability, delete the Gemfile.lock file. 
+
+# Instructions
+
+1. Register a GitHub account if you don't have one and confirm your e-mail (required!)
+1. Fork [this repository](https://github.com/academicpages/academicpages.github.io) by clicking the "fork" button in the top right. 
+1. Go to the repository's settings (rightmost item in the tabs that start with "Code", should be below "Unwatch"). Rename the repository "[your GitHub username].github.io", which will also be your website's URL.
+1. Set site-wide configuration and create content & metadata (see below -- also see [this set of diffs](http://archive.is/3TPas) showing what files were changed to set up [an example site](https://getorg-testacct.github.io) for a user with the username "getorg-testacct")
+1. Upload any files (like PDFs, .zip files, etc.) to the files/ directory. They will appear at https://[your GitHub username].github.io/files/example.pdf.  
+1. Check status by going to the repository settings, in the "GitHub pages" section
+1. (Optional) Use the Jupyter notebooks or python scripts in the `markdown_generator` folder to generate markdown files for publications and talks from a TSV file.
+
+See more info at https://academicpages.github.io/
+
+## To run locally (not on GitHub Pages, to serve on your own computer)
+
+1. Clone the repository and made updates as detailed above
+1. Make sure you have ruby-dev, bundler, and nodejs installed: `sudo apt install ruby-dev ruby-bundler nodejs`
+1. Run `bundle clean` to clean up the directory (no need to run `--force`)
+1. Run `bundle install` to install ruby dependencies. If you get errors, delete Gemfile.lock and try again.
+1. Run `bundle exec jekyll liveserve` to generate the HTML and serve it from `localhost:4000` the local server will automatically rebuild and refresh the pages on change.
+
+# Changelog -- bugfixes and enhancements
+
+There is one logistical issue with a ready-to-fork template theme like academic pages that makes it a little tricky to get bug fixes and updates to the core theme. If you fork this repository, customize it, then pull again, you'll probably get merge conflicts. If you want to save your various .yml configuration files and markdown files, you can delete the repository and fork it again. Or you can manually patch. 
+
+To support this, all changes to the underlying code appear as a closed issue with the tag 'code change' -- get the list [here](https://github.com/academicpages/academicpages.github.io/issues?q=is%3Aclosed%20is%3Aissue%20label%3A%22code%20change%22%20). Each issue thread includes a comment linking to the single commit or a diff across multiple commits, so those with forked repositories can easily identify what they need to patch.

--- a/scripts/generate_redirects.py
+++ b/scripts/generate_redirects.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""
+Generate redirect pages from _data/redirects.yml
+
+This script reads the redirects configuration and generates individual
+redirect pages in the _redirects/ directory.
+
+Usage:
+    python scripts/generate_redirects.py
+"""
+
+import os
+import yaml
+from pathlib import Path
+
+# Get the repo root directory (parent of scripts/)
+REPO_ROOT = Path(__file__).parent.parent
+DATA_FILE = REPO_ROOT / "_data" / "redirects.yml"
+REDIRECTS_DIR = REPO_ROOT / "_redirects"
+
+
+def load_redirects():
+    """Load redirects configuration from YAML file."""
+    if not DATA_FILE.exists():
+        print(f"Error: {DATA_FILE} not found")
+        return {}
+
+    with open(DATA_FILE, 'r') as f:
+        data = yaml.safe_load(f)
+
+    return data.get('redirects', {})
+
+
+def generate_redirect_page(source_path: str, destination_url: str) -> str:
+    """Generate the content for a redirect page."""
+    # Ensure the permalink has leading and trailing slashes
+    permalink = f"/{source_path.strip('/')}/"
+
+    return f"""---
+permalink: {permalink}
+redirect_to: {destination_url}
+---
+"""
+
+
+def main():
+    """Generate redirect pages from configuration."""
+    redirects = load_redirects()
+
+    if not redirects:
+        print("No redirects configured in _data/redirects.yml")
+        return 0
+
+    # Ensure the _redirects directory exists
+    REDIRECTS_DIR.mkdir(exist_ok=True)
+
+    # Get existing redirect files
+    existing_files = set(f.stem for f in REDIRECTS_DIR.glob("*.md"))
+    new_files = set()
+
+    print(f"Generating {len(redirects)} redirect(s)...")
+
+    for source_path, destination_url in redirects.items():
+        # Create a safe filename from the source path
+        filename = source_path.strip('/').replace('/', '_')
+        filepath = REDIRECTS_DIR / f"{filename}.md"
+        new_files.add(filename)
+
+        content = generate_redirect_page(source_path, destination_url)
+
+        # Check if file exists and content is the same
+        if filepath.exists():
+            with open(filepath, 'r') as f:
+                if f.read() == content:
+                    print(f"  [unchanged] /{source_path}/ -> {destination_url}")
+                    continue
+
+        with open(filepath, 'w') as f:
+            f.write(content)
+
+        print(f"  [generated] /{source_path}/ -> {destination_url}")
+
+    # Remove redirect files that are no longer in the config
+    removed_files = existing_files - new_files
+    for filename in removed_files:
+        filepath = REDIRECTS_DIR / f"{filename}.md"
+        filepath.unlink()
+        print(f"  [removed] {filename}.md (no longer in config)")
+
+    print("\nDone! Redirect pages are in _redirects/")
+    print("Run 'bundle exec jekyll serve' to test locally.")
+    return 0
+
+
+if __name__ == '__main__':
+    exit(main())


### PR DESCRIPTION
Summary
Add a configurable redirect system to redirect paths on this site to external URLs (e.g., /nnterp/ → ndif-team.github.io/nnterp/)
Create an automated build system using GitHub Actions that runs Python scripts before Jekyll builds
Build scripts are validated to ensure all are explicitly listed in a config file (enforces thinking about execution order)
How to Use
Adding a redirect
Edit _data/redirects.yml:

redirects:
  nnterp: https://ndif-team.github.io/nnterp/
  some/path: https://example.com/

Adding a build script
Create _build_scripts/my_script.py
Add it to _build_scripts/config.yml
Files Changed
_build_scripts/ - New folder for pre-build Python scripts
config.yml - Defines script execution order
run_build_scripts.py - Runner with validation
generate_redirects.py - Generates redirect pages from YAML
_data/redirects.yml - Configure redirects here
_layouts/redirect.html - Redirect page template
.github/workflows/deploy.yml - GitHub Actions workflow
README.md - New documentation
readme.old.md - Original template README (preserved)
Post-Merge Action Required
Go to Settings > Pages and change source from "Deploy from a branch" to "GitHub Actions".

You can create the PR at: https://github.com/Butanium/butanium.github.io/pull/new/claude/configurable-redirects-Nt3RP


Create PR
Reply...