### PR TITLE
Fix nnterp redirection for subpage links

### DIFF
--- a/_data/redirects.yml
+++ b/_data/redirects.yml
@@ -1,14 +1,19 @@
 # Configurable Redirects
-# Format: path_on_this_site: destination_url
 #
-# Example:
-#   nnterp: https://ndif-team.github.io/nnterp/
-#   foo/bar: https://bar.foo.com/
+# Two formats are supported:
+#
+# 1. Simple format (no subpath redirects):
+#    path: https://destination.com/
+#
+# 2. Object format (with configurable subpath redirects):
+#    path:
+#      url: https://destination.com/
+#      subpaths: true  # When true, /path/foo/bar.html -> https://destination.com/foo/bar.html
 #
 # These redirects are automatically generated during the GitHub Actions build.
 # Just edit this file and push - no manual steps needed!
 
 redirects:
-  nnterp: https://ndif-team.github.io/nnterp/
-  # Example nested path (remove this if not needed):
-  # foo/bar: https://bar.foo.com/
+  nnterp:
+    url: https://ndif-team.github.io/nnterp/
+    subpaths: true

--- a/_pages/404.md
+++ b/_pages/404.md
@@ -17,7 +17,8 @@ permalink: /404.html
   for (var pattern in subpathRedirects) {
     if (path.startsWith(pattern)) {
       var subpath = path.substring(pattern.length);
-      var destination = subpathRedirects[pattern] + subpath + window.location.search + window.location.hash;
+      var base = subpathRedirects[pattern].replace(/\/+$/, ''); // Remove trailing slashes
+      var destination = base + '/' + subpath + window.location.search + window.location.hash;
       window.location.replace(destination);
       return;
     }

--- a/_pages/404.md
+++ b/_pages/404.md
@@ -5,6 +5,26 @@ sitemap: false
 permalink: /404.html
 ---
 
+<script type="text/javascript">
+(function() {
+  // Subpath redirects - generated from _data/redirects.yml entries with subpaths: true
+  var subpathRedirects = {
+    {% for redirect in site.data.redirects.redirects %}{% if redirect[1].subpaths %}'/{{ redirect[0] }}/': '{{ redirect[1].url }}'{% unless forloop.last %},
+    {% endunless %}{% endif %}{% endfor %}
+  };
+
+  var path = window.location.pathname;
+  for (var pattern in subpathRedirects) {
+    if (path.startsWith(pattern)) {
+      var subpath = path.substring(pattern.length);
+      var destination = subpathRedirects[pattern] + subpath + window.location.search + window.location.hash;
+      window.location.replace(destination);
+      return;
+    }
+  }
+})();
+</script>
+
 Sorry, but the page you were trying to view does not exist --- perhaps you can try searching for it below.
 
 <script type="text/javascript">


### PR DESCRIPTION
Enable automatic redirection of subpaths (e.g., /nnterp/model-validation.html) to the corresponding path on the destination site. This is controlled via a new `subpaths: true` option in _data/redirects.yml.

The 404 page now includes JavaScript that checks for subpath redirect patterns and redirects accordingly, preserving query strings and hash fragments.