### PR TITLE
Fix JS comment breaking redirect when compress_html is enabled

### DIFF
--- a/_pages/404.md
+++ b/_pages/404.md
@@ -17,7 +17,7 @@ permalink: /404.html
   for (var pattern in subpathRedirects) {
     if (path.startsWith(pattern)) {
       var subpath = path.substring(pattern.length);
-      var base = subpathRedirects[pattern].replace(/\/+$/, ''); // Remove trailing slashes
+      var base = subpathRedirects[pattern].replace(/\/+$/, ''); /* Remove trailing slashes */
       var destination = base + '/' + subpath + window.location.search + window.location.hash;
       window.location.replace(destination);
       return;


### PR DESCRIPTION
compress_html collapses all code onto one line, causing // comments to comment out the rest of the script. Use /* */ instead.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a comment-style change in the 404 redirect script to avoid `compress_html` turning `//` into a line-ending comment that can swallow the rest of the minified script.
> 
> **Overview**
> Fixes the 404 subpath redirect script when `compress_html` collapses the page into a single line by replacing an inline `//` comment with a block `/* ... */` comment, preventing the remainder of the redirect logic from being commented out.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit da1978bf7f288f1340aa2b4ea476892f7dff8829. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->