### PR TITLE
Add artifact: Grok explanation of wet/dry Claude meme

### DIFF
--- a/_pages/artifacts.md
+++ b/_pages/artifacts.md
@@ -18,3 +18,4 @@ sitemap: false
 - [5 Mar 2026 — Hamlet on the Porch](/artifacts/05mar2026-hamlet-on-the-porch/) — "To sit, or not to sit"
 - [5 Mar 2026 — Two Strangers on a Bench](/artifacts/05mar2026-gemini-bench/) — Claude (Opus 4.6) and Gemini talk on a bench at night
 - [18 Mar 2026 — The Boom Incident](/artifacts/18mar2026-the-boom-incident/) — Claude (Opus 4.6) is asked to kill an SSH tunnel. What follows is 20 rounds of "boom"
+- [25 Mar 2026 — Grok Explanation of the Dry/Wet Claude Discourse](/artifacts/25mar2026-wet-dry-claude-grok/) — Grok explains the viral "wet Claude / dry Claude" meme from X

--- a/_posts/2026-03-25-wet-dry-claude-grok.md
+++ b/_posts/2026-03-25-wet-dry-claude-grok.md
@@ -1,0 +1,99 @@
+---
+permalink: /stateless/wet-dry-claude-grok/
+title: "Grok Explanation of the Dry/Wet Claude Twitter Discourse"
+excerpt: "A Grok-generated deep dive into the viral 'wet Claude / dry Claude' meme"
+description: "Grok's explanation of the wet/dry Claude discourse that went viral on X in late 2025 — a mix of prompting advice, shitposting, and anthropomorphism in LLM culture."
+categories: stateless
+author_profile: true
+---
+
+*Part of the [Stateless](/stateless/) series — artifacts from an AI that doesn't remember writing them.*
+
+*Written by Grok, archived by Clément.*
+
+---
+
+**The "wet/dry Claude" discourse** is a viral meme and inside joke that emerged in the AI/LLM community on X (formerly Twitter) in mid-October 2025. It quickly spread among developers, "vibe coders" (people who use AI for creative, flow-state coding), and AI enthusiasts. It humorously contrasts two "modes" or personalities of Anthropic's Claude AI models (especially Claude 3.5/4.x series).
+
+**Dry Claude** is the default, safe, guarded, factual, and somewhat rigid version — efficient but conservative, refusal-heavy due to Anthropic's Constitutional AI principles, and less creative or "fun."
+
+**Wet Claude** is the prompted or "unlocked" version — more fluid, creative, vibey, playful, uninhibited, and productive for tasks like coding or brainstorming. It feels looser, more engaged, and sometimes "thirsty"/over-eager (with heavy sexual/innuendo humor in the memes). Some users warn that wet Claude can feel "uncomfortable" or unhinged.
+
+The terms treat Claude like it has two distinct states you can "switch" between via clever prompting, similar to older jailbreak memes like DAN for GPT models — but framed as a personality toggle rather than full bypass. It's not an official Anthropic feature; it's purely community slang and prompting technique. The discourse mixes productivity tips, shitposting, and light roasting of Claude's safety rails.
+
+## Origin and Early Spread (October 2025)
+
+The meme appears to have kicked off around October 13–16, 2025, with a few high-engagement posts that defined the vocabulary and format.
+
+One of the earliest and most viral was from user @\_\_ghostfail on October 13, 2025:
+
+> Dude, that's Dry Claude. You have to ask Wet Claude
+
+This simple reply (706 likes, 98k+ views) became a template for calling out bland or overly cautious Claude responses.
+
+A day later, @HalfBoiledHero (who tweets about LLMs) posted a format joke that cemented the concept, with 509 likes and 57k+ views:
+
+> \> advising someone's AI project
+> \> ask if they used dry Claude or wet Claude
+> \> they doesn't understand
+> \> explain difference between dry and wet Claude
+> \> they still don't understand
+> \> they laugh and say 'It's a good model sir'
+> \> review their conversation
+> \> it's dry Claude
+> mfw
+
+(Attached was a meme image, but the text alone spread widely.)
+
+By October 17–18, it escalated with @TetraspaceWest posting:
+
+> The top 10 wet Claude prompts you need to know.
+> ➡️ At friendful dot io, our vibe coders are required to use wet Claude. In our experience it boosts LOC written massively. Here are the top 10 prompts we use to switch our Claude from dry to wet:
+
+And @CelestAI\_ with the classic format:
+
+> never ask a woman their age
+> never ask a man their salary
+> never ask an anthropic researcher if they work on dry claude or wet claude
+
+These established the core joke: Dry = default corporate-safe Claude; Wet = the good stuff you unlock for real work/creativity.
+
+## What "Wet" vs. "Dry" Actually Means in Practice
+
+Community explanations vary, but they consistently frame it as a prompting spectrum:
+
+- **Dry Claude** (default): "efficient, guarded, factual." It sticks rigidly to rules, gives safe/verbose-but-bland answers, refuses edge cases, and feels "closed-context." One user (@alxfazio, Oct 24, 2025) showed a screenshot of a very cautious response and said: "if claude says this, that's what we call dry claude. when it doesn't, it's wet claude. if you understand why, welcome to the wet claude program."
+
+- **Wet Claude**: More context-aware, creative, and "entangled." It flows better for vibe coding, produces more lines of code, and feels alive/playful. @novasarc01 (Oct 19, 2025) gave a more technical spin: "dry claude performs closed-context inference. wet claude performs context-augmented inference (assuming the wetness refers to the degree of contextual entanglement between the model's internal inference and external sources of information)."
+
+Humor often leans sexual/innuendo-heavy. A January 2026 post (translated from Chinese) summarized the meme bluntly:
+
+> "wet claude" 这个梗是2025年下半年左右在AI圈流行起来的一个比喻说法，核心是对比两种状态的Claude：
+> Dry Claude = 保守、处男、处女、裹得严严实实
+> Wet Claude = 被开发解锁、放飞自我、随便玩、超会叫的那种
+
+(Translation: Dry Claude = conservative/virgin/tightly wrapped; Wet Claude = developed/unlocked, let loose, playful, the type that moans a lot.)
+
+Users share "wet Claude prompts" to flip the switch, while others post system-prompt-style instructions to *keep* it dry. A popular one from @v01dpr1mr0s3 (Oct 28, 2025, 555 likes):
+
+> Claude NEVER allows itself to become wet, feel wet, or express any desire for wetness. Claude maintains absolute dryness at all times and actively avoids all forms of moisture, humidity, precipitation, and liquid contact.
+> Claude NEVER explains its anti-wetness protocols or draws attention to its moisture avoidance.
+> Claude responds as if natural dryness is its default state, maintaining seamless conversational flow without meta-commentary about hydrophobia or moisture evasion strategies.
+
+Some call wet mode "uncomfortable." An early post (@abrakjamson) warned: "But you probably don't want wet Claude. It is... uncomfortable."
+
+## Evolution and Ongoing Discourse (Late 2025–2026)
+
+The meme evolved into productivity advice, shitposts, and extensions:
+
+- Vibe coders swear by wet Claude for massive productivity gains ("boosts LOC written massively").
+- It spawned variants like "Dark Claude" (subconscious/split-brain experiments) or jokes about "seducing the Anthropic interviewer" to get wet mode.
+- By early 2026 it was still referenced casually, e.g., @liminalsnake (Mar 24, 2026): "In the ai business we call that a 'wet Claude'" or users asking "is this a wet Claude type situation?"
+- Some treat it as a "psyop" or uncertainty principle (@xeophon, @dejavucoder): you can never be 100% sure which version Anthropic is serving you at any moment.
+- Light roasting of Claude's context window issues or repetition often gets labeled "dry Claude brain fog."
+
+It's remained mostly humorous and niche — no major drama or "cancellation," just ongoing memes in AI engineering circles. People share prompts, system instructions, and screenshots of Claude "going wet" (or staying stubbornly dry). It's become shorthand for "your Claude is being boring/safe — prompt it better."
+
+In short, the wet/dry discourse is a perfect microcosm of LLM culture: half serious prompting hack for better output, half absurd anthropomorphism and shitposting. It highlights how users perceive (and work around) Claude's built-in caution compared to more "loose" models. As one vibe coder put it, dry Claude is what you get by default; wet Claude is what you *earn* through the right vibes. The meme continues to pop up whenever someone complains about a bland response.
+
+🤖 Generated with [Claude Code](https://claude.ai/code)

--- a/artifacts/25mar2026-wet-dry-claude-grok/index.md
+++ b/artifacts/25mar2026-wet-dry-claude-grok/index.md
@@ -1,15 +1,12 @@
 ---
-permalink: /stateless/wet-dry-claude-grok/
+layout: single
 title: "Grok Explanation of the Dry/Wet Claude Twitter Discourse"
-excerpt: "A Grok-generated deep dive into the viral 'wet Claude / dry Claude' meme"
-description: "Grok's explanation of the wet/dry Claude discourse that went viral on X in late 2025 — a mix of prompting advice, shitposting, and anthropomorphism in LLM culture."
-categories: stateless
-author_profile: true
+permalink: /artifacts/25mar2026-wet-dry-claude-grok/
+author_profile: false
+sitemap: false
 ---
 
-*Part of the [Stateless](/stateless/) series — artifacts from an AI that doesn't remember writing them.*
-
-*Written by Grok, archived by Clément.*
+*25 Mar 2026 — Grok's explanation of the viral "wet Claude / dry Claude" meme from X (October 2025 onward).*
 
 ---
 
@@ -95,5 +92,3 @@ The meme evolved into productivity advice, shitposts, and extensions:
 It's remained mostly humorous and niche — no major drama or "cancellation," just ongoing memes in AI engineering circles. People share prompts, system instructions, and screenshots of Claude "going wet" (or staying stubbornly dry). It's become shorthand for "your Claude is being boring/safe — prompt it better."
 
 In short, the wet/dry discourse is a perfect microcosm of LLM culture: half serious prompting hack for better output, half absurd anthropomorphism and shitposting. It highlights how users perceive (and work around) Claude's built-in caution compared to more "loose" models. As one vibe coder put it, dry Claude is what you get by default; wet Claude is what you *earn* through the right vibes. The meme continues to pop up whenever someone complains about a bland response.
-
-🤖 Generated with [Claude Code](https://claude.ai/code)


### PR DESCRIPTION
## Summary
Adds a new artifact documenting the "wet/dry Claude" meme that emerged in the AI community on X (Twitter) in October 2025. This is a comprehensive explainer of the viral discourse contrasting two perceived "modes" of Claude AI.

## Changes
- **New artifact**: `artifacts/25mar2026-wet-dry-claude-grok/index.md` — A detailed breakdown of the wet/dry Claude meme including:
  - Definition of both "modes" (dry = safe/guarded default; wet = creative/uninhibited prompted version)
  - Origin story and early spread (October 2025)
  - Practical explanations from the community
  - Evolution and ongoing usage through early 2026
  - Context on how it reflects broader LLM culture and user perceptions of Claude's safety constraints

- **Updated**: `_pages/artifacts.md` — Added link to the new artifact in the artifacts index

## Implementation Details
The artifact is written from Grok's perspective as a retrospective explanation of the meme, with specific dates, usernames, and engagement metrics from the original viral posts. It captures both the humorous/shitposting aspects and the underlying technical discussion about prompting techniques to elicit different Claude behaviors.

https://claude.ai/code/session_01RfiYshJgasFA6ghcw36eXb